### PR TITLE
Update ls.blur-up.js - Add webP to image types

### DIFF
--- a/plugins/blur-up/ls.blur-up.js
+++ b/plugins/blur-up/ls.blur-up.js
@@ -20,7 +20,7 @@
 
 	var slice = [].slice;
 	var regBlurUp = /blur-up["']*\s*:\s*["']*(always|auto)/;
-	var regType = /image\/(jpeg|png|gif|svg\+xml)/;
+	var regType = /image\/(jpeg|png|gif|svg\+xml|webp)/;
 	var transSrc = 'data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==';
 
 	var matchesMedia = function (source) {


### PR DESCRIPTION
This small change allows one to have different types  low resolution images.

```
<picture>
    <source 
        data-srcset=" ... webp images ..."
        data-lowsrc="low_res.webp"
        type="image/webp"/>

    <source 
        data-srcset=" ... jpeg images ..."
        data-lowsrc="low_res.jpg"
        type="image/jpeg"/>

    <img class="lazyload" data-sizes="auto" />
</picture>
```